### PR TITLE
Add option (disabled by default) to protect old backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ Simple script to help manage tarsnap backups by removing unwanted files accordin
 
 Tsar only manages cleanup of existing archives, but does so in a simple and straight-forward way. The manner in which the archives have been created or their naming conventions play no role in Tsar's function, as it uses archive creation dates obtained from Tarsnap. It will keep the specified number of daily, weekly and monthly backups, deleting the rest. It may be run with cron (if configured with a non-passphrased Tarsnap key), or manually.
 
-A few parameters are editable directly within the script, such as the number of daily, weekly and monthly backups to keep, as well as days of the week and days of the month to preserve for weekly and monthly backups. As Tsar runs the `tarsnap` command twice - once to obtain the list of archives, and again to delete them as necessary - different commands may be specified for each execution. This is handy when different keys or configuration files and options are used for different tarsnap tasks, or if you wish to supply Tsar with a list of archives from a different source - just replace the command and make sure its output is a list of archives in the same format as produced by `tarsnap -v --list-archives`.
+A few parameters are editable directly within the script, such as the number of daily, weekly and monthly backups to keep, as well as days of the week and days of the month to preserve for weekly and monthly backups.
+
+It is possible to protect older backups not using this scheme from deletion. Check the options in the script before first run.
+
+Tsar runs the `tarsnap` command twice - once to obtain the list of archives, and again to delete them as necessary - and different commands may be specified for each execution. This is handy when different keys or configuration files and options are used for different tarsnap tasks, or if you wish to supply Tsar with a list of archives from a different source - just replace the command and make sure its output is a list of archives in the same format as produced by `tarsnap -v --list-archives`.
 
 Once configured, Tsar may be executed without any parameters. A couple of flags are available, however:
 ```

--- a/tsar.sh
+++ b/tsar.sh
@@ -25,6 +25,9 @@ DAILY=30
 WEEKLY=12
 MONTHLY=48
 
+# Uncomment to preserve backups older than x months:
+# IGNORE=4
+
 DOW=1 # Day of the week for weekly # 0 is Sunday
 DOM=1 # Day of the month for monthly
 
@@ -49,6 +52,7 @@ DATE=$(date +%D)
 DAILY_DIFF_SEC=$((DAILY*86400))
 WEEKLY_DIFF_SEC=$((WEEKLY*604800))
 MONTHLY_DATE_UNIX=$(date +%s -d "$DATE -$MONTHLY months")
+if [ $IGNORE ];then MONTHLY_MAX_UNIX=$(date +%s -d "$DATE -$IGNORE months");fi
 
 if [ "$VERBOSE" -eq 1 ];then echo "Getting the list of archives from Tarsnap";fi
 $TARSNAP_R > "$LIST"
@@ -81,6 +85,11 @@ while read -r line;do
             echo "File younger than $MONTHLY months and its DOM is $FILE_DOM, not touching: $FILE_NAME"
         fi
         continue
+	elif [ $IGNORE ] && [ "$MONTHLY_MAX_UNIX" -gt "$FILE_UNIX" ];then
+		if [ "$VERBOSE" -eq 1 ];then
+			echo "File older than $IGNORE months, not touching: $FILE_NAME"
+		fi
+		continue
     fi
 
     echo "$FILE_NAME" >> "$LIST_TO_DELETE"


### PR DESCRIPTION
I want to use your script to rotate my backups but I have some older ones which I do not want deleted.

This implementation uses "do not delete if older than ___ months" because that is more convenient to me than trying to figure out an exact date.

Tested using ./tsar -vd .